### PR TITLE
PB-2118-MAY-848 Update deprecated after_filter

### DIFF
--- a/lib/memcaches_page.rb
+++ b/lib/memcaches_page.rb
@@ -5,7 +5,7 @@ module MemcachesPage
       return unless perform_caching
       options = actions.extract_options!
 
-      after_filter({:only => actions}.merge(options)) do |c|
+      after_action({:only => actions}.merge(options)) do |c|
         c.memcache_page(options)
       end
     end


### PR DESCRIPTION
The rails `after_filter` method is deprecated.

It has been replaced with `after_action` (same functionality).